### PR TITLE
Bump dependency in droid-parent to dependency-check-maven 5.2.3

### DIFF
--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -246,7 +246,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.2.1</version>
+                <version>5.2.3</version>
                 <configuration>
                     <failBuildOnCVSS>8</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>


### PR DESCRIPTION
To prevent a 404 when downloading the nvdcve metadata file.

See https://github.com/jeremylong/DependencyCheck/issues/2860#issuecomment-702827349 and https://github.com/ProgrammeVitam/sedatools/issues/31